### PR TITLE
Change PyPI publish to trigger on GitHub releases

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -28,8 +28,10 @@ jobs:
         run: uv sync
 
       - name: Verify version matches tag
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${TAG_NAME#v}"
           PKG_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "Error: Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"


### PR DESCRIPTION
## Summary
- Change the deploy-package workflow to trigger on GitHub releases instead of every push to main
- Add version verification step that ensures the git tag (e.g., `v0.2.1`) matches the version in `pyproject.toml`
- This prevents CI/CD failures from forgotten version bumps and gives explicit control over when packages are published

## New Release Process
After merging this PR, the release workflow becomes:

```bash
# 1. Bump version
uv version patch  # or minor/major

# 2. Commit and push
git add pyproject.toml uv.lock
git commit -m "Bump version to X.Y.Z"
git push

# 3. Create GitHub Release (this triggers PyPI publish)
gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes"
```

## Test plan
- [x] All existing tests pass
- [ ] After merge: push to main should NOT trigger PyPI publish
- [ ] Creating a GitHub release should trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now runs on published release events instead of pushes to main.
  * Added a pre-deploy verification that compares the release tag version with the package version and stops the release if they do not match.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->