### PR TITLE
Add create-release Claude command

### DIFF
--- a/.claude/commands/commit-changes.md
+++ b/.claude/commands/commit-changes.md
@@ -1,6 +1,10 @@
+---
+description: Commit unstaged changes with proper workflow
+---
+
 Please help me commit unstaged changes to the git repository.
 
-Follow these steps exactly, with no deviations:
+Follow these steps exactly:
 
 1. Ensure we are on a safe branch (e.g., not on 'main' or 'master').
 2. Check the format and quality of the code using linters or formatters as needed.

--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -1,0 +1,59 @@
+Please help me create a new release for this package.
+
+Follow these steps exactly:
+
+## Step 1: Verify Prerequisites
+1. Ensure we are on the `main` branch with a clean working directory
+2. Pull the latest changes: `git pull origin main`
+3. Run tests to ensure everything passes: `uv run pytest`
+
+## Step 2: Determine Version Bump
+Ask me what type of release this is:
+- `patch` - Bug fixes only (0.2.0 → 0.2.1)
+- `minor` - New features, backwards compatible (0.2.0 → 0.3.0)
+- `major` - Breaking changes (0.2.0 → 1.0.0)
+
+## Step 3: Review Changes Since Last Release
+Check what has changed since the last release to help determine version type and release notes:
+```bash
+# If tags exist, show commits since last tag
+git log $(git describe --tags --abbrev=0 2>/dev/null || echo "")..HEAD --oneline
+
+# If no tags exist, show recent commits
+git log --oneline -20
+```
+
+## Step 4: Create Release Branch and Bump Version
+1. Create a release branch: `git checkout -b release/v<new-version>`
+2. Bump the version: `uv version --bump <level>`
+3. Commit the version bump: `git add pyproject.toml uv.lock && git commit -m "Bump version to <new-version>"`
+4. Push the branch: `git push -u origin release/v<new-version>`
+
+## Step 5: Create and Merge PR
+1. Create a PR for the version bump:
+   ```bash
+   gh pr create --title "Release v<new-version>" --body "Bump version for release v<new-version>"
+   ```
+2. Wait for PR approval and merge (or merge immediately if appropriate)
+3. Switch back to main and pull: `git checkout main && git pull`
+
+## Step 6: Create GitHub Release
+Create the release using GitHub CLI with auto-generated notes:
+```bash
+gh release create v<new-version> --generate-notes --title "v<new-version>"
+```
+
+The `--generate-notes` flag automatically generates release notes from merged PRs since the last release. If you want to add custom notes, use:
+```bash
+gh release create v<new-version> --generate-notes --title "v<new-version>" --notes "Additional notes here"
+```
+
+## Step 7: Verify Release
+1. Check that the GitHub Actions workflow started: `gh run list --workflow=deploy-package.yml`
+2. Monitor the workflow: `gh run watch`
+3. Verify the package is published on PyPI
+
+## Important Notes
+- The release tag (e.g., `v0.3.0`) MUST match the version in `pyproject.toml` (e.g., `0.3.0`)
+- The deploy workflow verifies this match and will fail if they don't align
+- Always create releases from the `main` branch after the version bump PR is merged

--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -21,11 +21,12 @@ If a version bump type was provided as an argument (`$1`), use it. Otherwise, as
 ## Step 3: Review Changes Since Last Release
 Check what has changed since the last release to help determine version type and release notes:
 ```bash
-# If tags exist, show commits since last tag
-git log $(git describe --tags --abbrev=0 2>/dev/null || echo "")..HEAD --oneline
-
-# If no tags exist, show recent commits
-git log --oneline -20
+# If tags exist, show commits since last tag; otherwise, show recent commits
+if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+  git log "$(git describe --tags --abbrev=0)"..HEAD --oneline
+else
+  git log --oneline -20
+fi
 ```
 
 ## Step 4: Create Release Branch and Bump Version

--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -1,3 +1,8 @@
+---
+argument-hint: [patch|minor|major]
+description: Create a new release
+---
+
 Please help me create a new release for this package.
 
 Follow these steps exactly:
@@ -8,7 +13,7 @@ Follow these steps exactly:
 3. Run tests to ensure everything passes: `uv run pytest`
 
 ## Step 2: Determine Version Bump
-Ask me what type of release this is:
+If a version bump type was provided as an argument (`$1`), use it. Otherwise, ask me what type of release this is:
 - `patch` - Bug fixes only (0.2.0 → 0.2.1)
 - `minor` - New features, backwards compatible (0.2.0 → 0.3.0)
 - `major` - Breaking changes (0.2.0 → 1.0.0)

--- a/.claude/commands/get-pr-feedback.md
+++ b/.claude/commands/get-pr-feedback.md
@@ -1,9 +1,14 @@
-Please help me address the comments on the PR for this branch.
+---
+argument-hint: [pr-number]
+description: Address comments on a pull request
+---
+
+Please help me address the comments on a PR.
 
 Follow these steps:
 
 1. In plan mode:
-  1. Get the PR number for the active branch: `gh pr list --head $(git branch --show-current) --json number`
+  1. If a PR number was provided as an argument (`$1`), use it. Otherwise, get the PR number for the active branch: `gh pr list --head $(git branch --show-current) --json number`
   2. Get unresolved review threads using GraphQL (replace OWNER, REPO, PR_NUMBER):
      ```
      gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes { isResolved path line comments(first: 10) { nodes { body author { login } } } } } } } }' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))'

--- a/.claude/commands/get-pr-feedback.md
+++ b/.claude/commands/get-pr-feedback.md
@@ -8,18 +8,18 @@ Please help me address the comments on a PR.
 Follow these steps:
 
 1. In plan mode:
-  1. If a PR number was provided as an argument (`$1`), use it. Otherwise, get the PR number for the active branch: `gh pr list --head $(git branch --show-current) --json number`
-  2. Get unresolved review threads using GraphQL (replace OWNER, REPO, PR_NUMBER):
-     ```
-     gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes { isResolved path line comments(first: 10) { nodes { body author { login } } } } } } } }' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))'
-     ```
-  3. Also fetch general PR comments: `gh pr view <pr-number> --comments --json comments`
-  4. Review the PR comments carefully and make a list of the requested changes or feedback.
-  5. For each comment, be critical and consider the best way to address the feedback, whether it's code changes, documentation updates, or other modifications. You may decide not to address some comments if they are not applicable.
-  6. Summarize your plan for addressing each comment, including any questions or clarifications needed.
+   1. If a PR number was provided as an argument (`$1`), use it. Otherwise, get the PR number for the active branch: `gh pr list --head $(git branch --show-current) --json number`
+   2. Get unresolved review threads using GraphQL (replace OWNER, REPO, PR_NUMBER):
+      ```
+      gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes { isResolved path line comments(first: 10) { nodes { body author { login } } } } } } } }' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))'
+      ```
+   3. Also fetch general PR comments: `gh pr view <pr-number> --comments --json comments`
+   4. Review the PR comments carefully and make a list of the requested changes or feedback.
+   5. For each comment, be critical and consider the best way to address the feedback, whether it's code changes, documentation updates, or other modifications. You may decide not to address some comments if they are not applicable.
+   6. Summarize your plan for addressing each comment, including any questions or clarifications needed.
 2. Implement the changes:
-  1. Make the necessary code changes or updates based on your plan.
-  2. Create clear and concise commit messages that reference the PR comments being addressed.
-  3. Push the changes to the branch associated with the PR.
-  4. Leave comments on the PR explaining how each piece of feedback was addressed. Tag `@coderabbitai` for review.
-  5. Leave a final comment for coderabbit to mark all of its previous comments as resolved: `@coderabbitai resolve`
+   1. Make the necessary code changes or updates based on your plan.
+   2. Create clear and concise commit messages that reference the PR comments being addressed.
+   3. Push the changes to the branch associated with the PR.
+   4. Leave comments on the PR explaining how each piece of feedback was addressed. Tag `@coderabbitai` for review.
+   5. Leave a final comment for coderabbit to mark all of its previous comments as resolved: `@coderabbitai resolve`

--- a/.claude/commands/upgrade-environment.md
+++ b/.claude/commands/upgrade-environment.md
@@ -1,6 +1,10 @@
+---
+description: Upgrade all packages to latest compatible versions
+---
+
 Please upgrade all installed packages to their latest (compatible) versions.
 
-Skip plan mode and follow these steps exactly, with no deviations:
+Skip plan mode and follow these steps exactly:
 
 1. Use `uv self update` to update the `uv` tool itself to the latest version.
 2. Use `uv sync --upgrade` to upgrade all installed packages to their latest compatible versions.


### PR DESCRIPTION
## Summary
- Add new `/create-release` Claude command with step-by-step instructions for creating package releases
- Covers version bumping, PR creation, GitHub release workflow, and verification steps

## Test plan
- [x] Tests pass
- [ ] Verify the command works as expected when invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step‑by‑step release guidance covering preparation, versioning, branch/PR workflow, release notes creation and post‑release checks.
  * Added metadata headers and clarified wording across command guidance documents.
* **Chores**
  * Clarified commit workflow with granular steps (including running tests, staged commits, push and PR guidance).
  * Made PR‑feedback command accept an optional PR number and added environment‑upgrade steps for inspecting/updating dependency versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->