### PR TITLE
Add Pydantic models for teams, events, element_types, and fixture stats

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,6 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-
-tools:
-  markdownlint:
-    enabled: false      # Disable to avoid conflicts with mdformat
+  tools:
+    markdownlint:
+      enabled: false  # Disable to avoid conflicts with mdformat

--- a/fplstat/api/models/__init__.py
+++ b/fplstat/api/models/__init__.py
@@ -1,5 +1,19 @@
 from .bootstrap.bootstrap import BootstrapStaticResponse
 from .bootstrap.element import Element
-from .fixtures import Fixture, FixturesResponse
+from .bootstrap.element_type import ElementType
+from .bootstrap.event import ChipPlay, Event
+from .bootstrap.team import Team
+from .fixtures import Fixture, FixturesResponse, FixtureStat, FixtureStatValue
 
-__all__ = ["BootstrapStaticResponse", "FixturesResponse", "Element", "Fixture"]
+__all__ = [
+    "BootstrapStaticResponse",
+    "ChipPlay",
+    "Element",
+    "ElementType",
+    "Event",
+    "Fixture",
+    "FixturesResponse",
+    "FixtureStat",
+    "FixtureStatValue",
+    "Team",
+]

--- a/fplstat/api/models/bootstrap/bootstrap.py
+++ b/fplstat/api/models/bootstrap/bootstrap.py
@@ -3,6 +3,9 @@ from typing import Any, Dict, List
 from pydantic import BaseModel, ConfigDict
 
 from .element import Element
+from .element_type import ElementType
+from .event import Event
+from .team import Team
 
 
 class BootstrapStaticResponse(BaseModel):
@@ -12,11 +15,11 @@ class BootstrapStaticResponse(BaseModel):
 
     chips: List[Dict[str, Any]]
     element_stats: List[Dict[str, Any]]
-    element_types: List[Dict[str, Any]]
+    element_types: List[ElementType]
     elements: List[Element]
-    events: List[Dict[str, Any]]
+    events: List[Event]
     game_config: Dict[str, Any]
     game_settings: Dict[str, Any]
     phases: List[Dict[str, Any]]
-    teams: List[Dict[str, Any]]
+    teams: List[Team]
     total_players: int

--- a/fplstat/api/models/bootstrap/element_type.py
+++ b/fplstat/api/models/bootstrap/element_type.py
@@ -1,0 +1,30 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ElementType(BaseModel):
+    """Model for FPL element type (position) data from bootstrap-static element_types"""
+
+    model_config = ConfigDict(extra="allow")
+
+    # Identifiers
+    id: int
+    singular_name: str
+    singular_name_short: str
+    plural_name: str
+    plural_name_short: str
+
+    # Squad requirements
+    squad_select: int
+    squad_min_play: int
+    squad_max_play: int
+    squad_min_select: Optional[int] = None
+    squad_max_select: Optional[int] = None
+
+    # Stats
+    element_count: int
+
+    # UI
+    ui_shirt_specific: bool
+    sub_positions_locked: List[int]

--- a/fplstat/api/models/bootstrap/event.py
+++ b/fplstat/api/models/bootstrap/event.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ChipPlay(BaseModel):
+    """Model for chip usage statistics in an event"""
+
+    model_config = ConfigDict(extra="allow")
+
+    chip_name: str
+    num_played: int
+
+
+class Event(BaseModel):
+    """Model for FPL event (gameweek) data from bootstrap-static events"""
+
+    model_config = ConfigDict(extra="allow")
+
+    # Identifiers
+    id: int
+    name: str
+
+    # Scheduling
+    deadline_time: datetime
+    release_time: Optional[datetime] = None
+
+    # Status flags
+    finished: bool
+    data_checked: bool
+    is_previous: bool
+    is_current: bool
+    is_next: bool
+
+    # Performance metrics (null for future gameweeks)
+    average_entry_score: Optional[int] = None
+    highest_score: Optional[int] = None
+    highest_scoring_entry: Optional[int] = None
+
+    # Participants
+    ranked_count: Optional[int] = None
+
+    # Chip usage
+    chip_plays: List[ChipPlay]
+
+    # Player stats (null for future gameweeks)
+    most_selected: Optional[int] = None
+    most_captained: Optional[int] = None
+    most_vice_captained: Optional[int] = None
+    most_transferred_in: Optional[int] = None
+    top_element: Optional[int] = None
+    top_element_info: Optional[Dict[str, Any]] = None
+
+    # Transfer stats
+    transfers_made: Optional[int] = None

--- a/fplstat/api/models/bootstrap/team.py
+++ b/fplstat/api/models/bootstrap/team.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class Team(BaseModel):
+    """Model for FPL team data from bootstrap-static teams"""
+
+    model_config = ConfigDict(extra="allow")
+
+    # Identifiers
+    id: int
+    code: int
+    name: str
+    short_name: str
+    pulse_id: int
+
+    # League standing
+    position: int
+    played: int
+    points: int
+    win: int
+    draw: int
+    loss: int
+
+    # Strength ratings
+    strength: int
+    strength_overall_home: int
+    strength_overall_away: int
+    strength_attack_home: int
+    strength_attack_away: int
+    strength_defence_home: int
+    strength_defence_away: int
+
+    # Status
+    unavailable: bool

--- a/fplstat/api/models/fixtures.py
+++ b/fplstat/api/models/fixtures.py
@@ -1,7 +1,26 @@
 from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import List, Union
 
 from pydantic import BaseModel, ConfigDict
+
+
+class FixtureStatValue(BaseModel):
+    """Model for a single stat value (goal, assist, etc.) in a fixture"""
+
+    model_config = ConfigDict(extra="allow")
+
+    value: int
+    element: int
+
+
+class FixtureStat(BaseModel):
+    """Model for fixture statistics (goals, assists, etc.)"""
+
+    model_config = ConfigDict(extra="allow")
+
+    identifier: str
+    a: List[FixtureStatValue]  # Away team stats
+    h: List[FixtureStatValue]  # Home team stats
 
 
 class Fixture(BaseModel):
@@ -19,7 +38,7 @@ class Fixture(BaseModel):
     provisional_start_time: bool
     pulse_id: int
     started: bool
-    stats: List[Dict[str, Any]]
+    stats: List[FixtureStat]
     team_a: int
     team_a_difficulty: int
     team_a_score: Union[int, None]

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -5,7 +5,15 @@ import pytest
 
 from fplstat import FPLStat
 from fplstat.api import APIClient
-from fplstat.api.models import BootstrapStaticResponse, Element, Fixture
+from fplstat.api.models import (
+    BootstrapStaticResponse,
+    Element,
+    ElementType,
+    Event,
+    Fixture,
+    FixtureStat,
+    Team,
+)
 
 
 @pytest.fixture(scope="session")
@@ -94,3 +102,62 @@ def test_get_fixtures():
     # Check it has expected columns
     expected_columns = {"team_h", "team_a", "kickoff_time", "finished"}
     assert expected_columns.issubset(fixtures_df.columns)
+
+
+@pytest.fixture
+def sample_team(bootstrap_static_data):
+    """Get a real team from live API data"""
+    return bootstrap_static_data.teams[0]
+
+
+def test_team_model(sample_team):
+    """Test that a sample team from live API data validates against Team model"""
+    assert isinstance(sample_team, Team)
+    assert hasattr(sample_team, "name")
+    assert hasattr(sample_team, "short_name")
+    assert hasattr(sample_team, "strength")
+
+
+@pytest.fixture
+def sample_event(bootstrap_static_data):
+    """Get a real event from live API data"""
+    return bootstrap_static_data.events[0]
+
+
+def test_event_model(sample_event):
+    """Test that a sample event from live API data validates against Event model"""
+    assert isinstance(sample_event, Event)
+    assert hasattr(sample_event, "name")
+    assert hasattr(sample_event, "deadline_time")
+    assert hasattr(sample_event, "finished")
+
+
+@pytest.fixture
+def sample_element_type(bootstrap_static_data):
+    """Get a real element type from live API data"""
+    return bootstrap_static_data.element_types[0]
+
+
+def test_element_type_model(sample_element_type):
+    """Test that a sample element type validates against ElementType model"""
+    assert isinstance(sample_element_type, ElementType)
+    assert hasattr(sample_element_type, "singular_name")
+    assert hasattr(sample_element_type, "plural_name")
+    assert hasattr(sample_element_type, "squad_select")
+
+
+def test_fixture_stat_model(fixtures_data):
+    """Test that fixture stats from live API data validate against FixtureStat model"""
+    # Find a finished fixture with stats
+    finished_fixtures = [f for f in fixtures_data.fixtures if f.finished]
+    if not finished_fixtures:
+        pytest.skip("No finished fixtures available for testing stats")
+
+    fixture = finished_fixtures[0]
+    assert isinstance(fixture.stats, list)
+    if fixture.stats:
+        stat = fixture.stats[0]
+        assert isinstance(stat, FixtureStat)
+        assert hasattr(stat, "identifier")
+        assert hasattr(stat, "a")
+        assert hasattr(stat, "h")


### PR DESCRIPTION
## Summary

- Add `Team` model for team data (league position, strength ratings)
- Add `Event` model for gameweek data (scheduling, status flags, chip usage)
- Add `ElementType` model for position data (squad requirements)
- Add `FixtureStat` and `FixtureStatValue` models for fixture statistics
- Update `BootstrapStaticResponse` to use typed models instead of `List[Dict[str, Any]]`
- Add integration tests validating all new models against live API

## Test plan

- [x] All 8 integration tests pass against live FPL API
- [x] Models validate correctly with `ConfigDict(extra="allow")` for API flexibility
- [x] Code formatted with ruff

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new public data models: ElementType, ChipPlay, Event, Team, FixtureStat, FixtureStatValue.

* **Improvements**
  * Replaced generic data structures in bootstrap and fixture responses with the new specific models for clearer, stricter data shapes.

* **Tests**
  * Expanded integration tests to cover the newly exported models and their attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->